### PR TITLE
One liner fix: Fix Streamdown import

### DIFF
--- a/app/markdown-renderer.tsx
+++ b/app/markdown-renderer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useMemo, useCallback } from 'react'
-import Streamdown from 'streamdown'
+import { Streamdown } from 'streamdown'
 import { CitationTooltip } from './citation-tooltip-portal'
 import { SearchResult } from './types'
 


### PR DESCRIPTION
I'm using `bun` in my project.

Without this edit, the console shows:

```
 ⨯ ./app/markdown-renderer.tsx:4:1
Export default doesn't exist in target module
  2 |
  3 | import React, { useMemo, useCallback } from 'react'
> 4 | import Streamdown from 'streamdown'
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  5 | import { CitationTooltip } from './citation-tooltip-portal'
  6 | import { SearchResult } from './types'
  7 |

The export default was not found in module [project]/node_modules/streamdown/dist/index.js [app-client] (ecmascript).
Did you mean to import Streamdown?
All exports of the module are statically known (It doesn't have dynamic exports). So it's known statically that the requested export doesn't exist.



./app/markdown-renderer.tsx:4:1
Export default doesn't exist in target module
  2 |
  3 | import React, { useMemo, useCallback } from 'react'
> 4 | import Streamdown from 'streamdown'
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  5 | import { CitationTooltip } from './citation-tooltip-portal'
  6 | import { SearchResult } from './types'
  7 |

The export default was not found in module [project]/node_modules/streamdown/dist/index.js [app-ssr] (ecmascript).
Did you mean to import Streamdown?
All exports of the module are statically known (It doesn't have dynamic exports). So it's known statically that the requested export doesn't exist.
```

and the browser shows:

<img width="1025" height="570" alt="image" src="https://github.com/user-attachments/assets/a5892c09-26e8-49e3-b7ca-a564bd616d74" />

With the one liner edit, the issue is unblocked.

Examining the diffs on the `bun repl`:

```ts
> import { Streamdown } from 'streamdown'
undefined
> Streamdown
{
  '$$typeof': Symbol(react.memo),
  type: [Function: Streamdown] { displayName: 'Streamdown' },
  compare: [Function (anonymous)]
}
```

```ts
> import Streamdown from 'streamdown'
> Streamdown
Object [Module] {
  ShikiThemeContext: <ref *1> {
    '$$typeof': Symbol(react.context),
    _currentValue: [ 'github-light', 'github-dark' ],
    _currentValue2: [ 'github-light', 'github-dark' ],
    _threadCount: 0,
    Provider: [Circular *1],
    Consumer: { '$$typeof': Symbol(react.consumer), _context: [Circular *1] },
    _currentRenderer: null,
    _currentRenderer2: null
  },
  Streamdown: {
    '$$typeof': Symbol(react.memo),
    type: [Function: Streamdown] { displayName: 'Streamdown' },
    compare: [Function (anonymous)]
  }
}
```